### PR TITLE
feat: load captured photos in gallery

### DIFF
--- a/src/app/services/photo.service.ts
+++ b/src/app/services/photo.service.ts
@@ -9,6 +9,7 @@ import { Preferences } from '@capacitor/preferences';
 })
 export class PhotoService {
   public photos: UserPhoto[] = [];
+  private PHOTO_STORAGE: string = 'photos';
 
   constructor() { }
   public async addNewToGallery() {
@@ -22,8 +23,29 @@ export class PhotoService {
     // Save the picture and add it to photo collection
     const savedImageFile = await this.savePicture(capturedPhoto);
     this.photos.unshift(savedImageFile);
-  }
 
+    Preferences.set({
+      key: this.PHOTO_STORAGE,
+      value: JSON.stringify(this.photos),
+    });
+  }
+  public async loadSaved() {
+    // Retrieve cached photo array data
+    const photoList:any = await Preferences.get({ key: this.PHOTO_STORAGE });
+    this.photos = JSON.parse(photoList.value) || [];
+  
+    // Display the photo by reading into base64 format
+for (let photo of this.photos) {
+  // Read each saved photo's data from the Filesystem
+  const readFile = await Filesystem.readFile({
+    path: photo.filepath,
+    directory: Directory.Data,
+  });
+
+  // Web platform only: Load the photo as base64 data
+  photo.webviewPath = `data:image/jpeg;base64,${readFile.data}`;
+}
+  }
   private async savePicture(photo: Photo) {
   // Convert photo to base64 format, required by Filesystem API to save
   const base64Data = await this.readAsBase64(photo);

--- a/src/app/tab2/tab2.page.ts
+++ b/src/app/tab2/tab2.page.ts
@@ -8,6 +8,10 @@ import { PhotoService } from '../services/photo.service';
 })
 export class Tab2Page {
 
+  async ngOnInit() {
+    await this.photoService.loadSaved();
+  }
+  
   constructor(public photoService: PhotoService) { }
 
   addPhotoToGallery() {


### PR DESCRIPTION
Changes to have captured photos retained in the tab-2 gallery. Now on page reloads, app restarts, and tab navigations the previously captured photos will be retained.